### PR TITLE
copia de imágenes en Docker Hub

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag retrobyte:$(date +%s)
+      run: docker build . --file backend/Dockerfile --tag retrobyte-be:$(date +%s)
+      run: docker build . --file frontend/Dockerfile --tag retrobyte-fe:$(date +%s)
+    - name: Log in to Docker Hub
+      run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Tag the Docker image
+      run: docker tag retrobyte-be:$(date +%s) mig1881/retrobyte-be:$(date +%s)
+      run: docker tag retrobyte-fe:$(date +%s) mig1881/retrobyte-fe:$(date +%s)
+
+    - name: Push the Docker image to Docker Hub
+      run: docker push mig1881/retrobyte-be:$(date +%s)
+      run: docker push mig1881/retrobyte-fe:$(date +%s)
+


### PR DESCRIPTION
Se configura github actions para que lanzar una imagen de forma automática del backend y del fronten a Docker Hub, ha habido que crear un token de seguridad en Docker Hub y después crear dos secrets en este repositorio para que pueda acceder git Hub a docker Hub utilizando el token que he creado en docker hub.